### PR TITLE
Revert shouldReturn-definition

### DIFF
--- a/src/Test/Hspec/Expectations/Lifted.hs
+++ b/src/Test/Hspec/Expectations/Lifted.hs
@@ -72,8 +72,8 @@ shouldMatchList = liftIO2 E.shouldMatchList
 -- |
 -- @action \`shouldReturn\` expected@ sets the expectation that @action@
 -- returns @expected@.
-shouldReturn :: (HasCallStack, MonadIO m, Show a, Eq a) => IO a -> a -> m ()
-shouldReturn = liftIO2 E.shouldReturn
+shouldReturn :: (HasCallStack, MonadIO m, Show a, Eq a) => m a -> a -> m ()
+shouldReturn action expected = action >>= liftIO . (`E.shouldBe` expected)
 
 -- |
 -- @actual \`shouldNotBe\` notExpected@ sets the expectation that @actual@ is not


### PR DESCRIPTION
Hi,

```shouldReturn``` definition is different from one of previous version.(see below.)
I think previous one is better, because action-type is generalized from IO.
Could you revert this definition?

current definition(0.8.2)
- shouldReturn :: (HasCallStack, MonadIO m, Show a, Eq a) => IO a -> a -> m ()  

previous definition(0.5.0)
- shouldReturn :: (Show a, Eq a, MonadIO m) => m a -> a -> m ()
