### PR TITLE
Revert shouldNotReturn-definition

### DIFF
--- a/src/Test/Hspec/Expectations/Lifted.hs
+++ b/src/Test/Hspec/Expectations/Lifted.hs
@@ -95,5 +95,5 @@ shouldNotContain = liftIO2 E.shouldNotContain
 -- |
 -- @action \`shouldNotReturn\` notExpected@ sets the expectation that @action@
 -- does not return @notExpected@.
-shouldNotReturn :: (HasCallStack, MonadIO m, Show a, Eq a) => IO a -> a -> m ()
-shouldNotReturn = liftIO2 E.shouldNotReturn
+shouldNotReturn :: (HasCallStack, MonadIO m, Show a, Eq a) => m a -> a -> m ()
+shouldNotReturn action expected = action >>= liftIO . (`E.shouldNotBe` expected)


### PR DESCRIPTION
Thank your for merging https://github.com/hspec/hspec-expectations-lifted/pull/2 .
I forgot ```shouldNotReturn```.
Could you merge this, too?
