### PR TITLE
adding shouldThrowException function

### DIFF
--- a/hspec-expectations-lifted.cabal
+++ b/hspec-expectations-lifted.cabal
@@ -20,8 +20,10 @@ library
       -Wall
   build-depends:
       base == 4.*
+    , exceptions
     , hspec-expectations >= 0.8.2
     , transformers
+    , mtl
   hs-source-dirs:
       src
   exposed-modules:


### PR DESCRIPTION
I needed to test a DB exception and it was a bit harsh.

I implemented `shouldThrowException` helper to be able to test it easily. So why not share it to the community?

Example of use with an `ErrorCall` `Exception`: 

```haskell
actionFunction `shouldThrowException` (ErrorCallWithLocation "My error message" "")
```